### PR TITLE
[EXAMPLE] Feature: Notifying security in case of check in/out anomaliees

### DIFF
--- a/src/Domain/Command/NotifySecurityOfCheckInAnomaly.php
+++ b/src/Domain/Command/NotifySecurityOfCheckInAnomaly.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Building\Domain\Command;
+
+use Prooph\Common\Messaging\Command;
+use Rhumsaa\Uuid\Uuid;
+
+final class NotifySecurityOfCheckInAnomaly extends Command
+{
+    /**
+     * @var Uuid
+     */
+    private $buildingId;
+
+    /**
+     * @var string
+     */
+    private $username;
+
+    private function __construct(Uuid $buildingId, string $username)
+    {
+        $this->init();
+
+        $this->buildingId = $buildingId;
+        $this->username = $username;
+    }
+
+    public static function with(Uuid $buildingId, string $username) : self
+    {
+        return new self($buildingId, $username);
+    }
+
+    public function buildingId() : Uuid
+    {
+        return $this->buildingId;
+    }
+
+    public function username() : string
+    {
+        return $this->username;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function payload() : array
+    {
+        return [
+            'buildingId' => $this->buildingId->toString(),
+            'username'   => $this->username,
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setPayload(array $payload)
+    {
+        $this->username = $payload['username'];
+        $this->buildingId = Uuid::fromString($payload['buildingId']);
+    }
+}

--- a/src/Domain/DomainEvent/CheckInAnomalyDetected.php
+++ b/src/Domain/DomainEvent/CheckInAnomalyDetected.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Building\Domain\DomainEvent;
+
+use Prooph\EventSourcing\AggregateChanged;
+use Rhumsaa\Uuid\Uuid;
+
+final class CheckInAnomalyDetected extends AggregateChanged
+{
+    public static function with(Uuid $buildingId, string $username) : self
+    {
+        return self::occur($buildingId->toString(), ['username' => $username]);
+    }
+
+    public function buildingId() : Uuid
+    {
+        return Uuid::fromString($this->aggregateId());
+    }
+
+    public function username() : string
+    {
+        return $this->payload['username'];
+    }
+}


### PR DESCRIPTION
Replaces logic in #3: instead of failures, you can now detect anomalies and react to them by notifying someone (security, in this case) via a separate command that will be executed in a new transactionally safe context